### PR TITLE
changed requirement for Mojolicious::Plugin::Subdispatch to 0.04

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ WriteMakefile(
         # non-trivial dependencies
         'File::Copy::Recursive'                 => '0.38',
         'Mojolicious'                           => '4.90',
-        'Mojolicious::Plugin::Subdispatch'      => '0.05',
+        'Mojolicious::Plugin::Subdispatch'      => '0.04',
         'Mojolicious::Plugin::RelativeUrlFor'   => '0.02',
         'Text::Markdown'                        => '1.000031',
     },

--- a/README
+++ b/README
@@ -14,7 +14,7 @@ PREREQUISITES
     - perl 5.10.1
     - File::Copy::Recursive 0.38
     - Mojolicious 4.20
-    - Mojolicious::Plugin::Subdispatch 0.03
+    - Mojolicious::Plugin::Subdispatch 0.04
     - Mojolicious::Plugin::RelativeUrlFor 0.02
     - Text::Markdown 1.000031
 


### PR DESCRIPTION
The readme stated '0.03' but Makefile.PL had '0.05', which wouldn't build (with cpanm). After installing version '0.04', attempting to run cpanm in the source directory generated this message:
```
! Installing the dependencies failed: Installed version (0.04) of Mojolicious::Plugin::Subdispatch is not in range '0.05'
! Bailing out the installation for Contenticious-0.333.
```
...so I updated Makefile.PL

