### PR TITLE
Use "reply" controller method for 404 not found (#12)

### DIFF
--- a/lib/Contenticious.pm
+++ b/lib/Contenticious.pm
@@ -54,7 +54,7 @@ sub startup {
         # found matching content node?
         my $content_node = $c->contenticious->find($path);
         unless (defined $content_node) {
-            $c->render_not_found;
+            $c->reply->not_found;
             return;
         }
 


### PR DESCRIPTION
Current Mojolicious 6.X does not support `render_not_found()` method anymore. Due to old method call, `t/04_webapp.t` 404 related tests failed.

https://metacpan.org/source/SRI/Mojolicious-6.11/Changes#L93