### PR TITLE
Real/currents

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ See their documentation for details. To install it manually,
 download the dist tarball or clone the git repository
 and execute the following standard procedure:
 
+    $ cpanm --notest .
     $ perl Makefile.PL
     $ make
     $ make test

--- a/lib/Contenticious.pm
+++ b/lib/Contenticious.pm
@@ -1,7 +1,7 @@
 package Contenticious;
 use Mojo::Base 'Mojolicious';
 
-our $VERSION = '0.35';
+our $VERSION = '0.35.1';
 
 use Contenticious::Content;
 use Carp;

--- a/t/04_webapp.t
+++ b/t/04_webapp.t
@@ -9,8 +9,12 @@ use FindBin '$Bin';
 use lib "$Bin/../lib";
 use Contenticious::Generator;
 use utf8;
+use Mojo::Log;
+
+my $log = Mojo::Log->new;
 
 # prepare web app
+$log->debug("Bin: $Bin\n");
 chdir $Bin;
 ok(! -d 'public', "public directory doesn't exist");
 my $gen = Contenticious::Generator->new(quiet => 1);
@@ -21,6 +25,8 @@ $ENV{CONTENTICIOUS_CONFIG} = "$Bin/test_config";
 # build web app tester
 $ENV{MOJO_HOME} = $Bin;
 my $t = Test::Mojo->new('Contenticious');
+
+$t->app->log->level('debug');
 
 # home page: listing of foo, bar, baz
 $t->get_ok('/')->status_is(200)
@@ -155,7 +161,7 @@ $t->text_like('#copyright' => qr/Zaphod Beeblebrox/);
 # styles.css: stylesheet
 $t->get_ok('/styles.css')->status_is(200)
   ->content_type_is('text/css')
-  ->content_like(qr/^html, body {/);
+  ->content_like(qr/^html, body \{/);
 
 # 404
 $t->get_ok('/foomatic')->status_is(404)
@@ -168,7 +174,7 @@ $t->get_ok('/foomatic')->status_is(404)
 # perldoc
 $t->get_ok('/perldoc/Contenticious')->status_is(200)
   ->text_is(title => 'Contenticious - build web sites from markdown files')
-  ->text_is('h1 a#NAME' => 'NAME');
+  ->text_is('li a[href="#NAME"]' => 'NAME');
 
 # done
 remove_tree('public');

--- a/t/05_dump.t
+++ b/t/05_dump.t
@@ -38,7 +38,7 @@ require("$Bin/webapp.pl");
 
 # stylesheet
 ok(-f -r "$dd/styles.css", 'stylesheet found');
-like(slurp("$dd/styles.css"), qr/#built_with a {/, 'right stylesheet');
+like(slurp("$dd/styles.css"), qr/#built_with a \{/, 'right stylesheet');
 
 # index
 ok(-f -r "$dd/index.html", 'index found');

--- a/t/06_script.t
+++ b/t/06_script.t
@@ -79,7 +79,7 @@ like(
     'right About page',
 );
 ok(-f "$init_dir/public/styles.css", 'public/styles.css exists');
-like(slurp("$init_dir/public/styles.css"), qr/html, body {/, 'right css');
+like(slurp("$init_dir/public/styles.css"), qr/html, body \{/, 'right css');
 
 # cleanup
 chdir $Bin or die "W00T! $!";


### PR DESCRIPTION
I was having some issues with my installed version of Contenticious calling "render_not_found", which I eventually figured out by reading: https://github.com/kraih/mojo/issues/674

Even though the latest Contenticious code has been corrected to use "reply->not_found", cpan thinks I have the latest version installed (0.35), so I cannot upgrade to corrected code. So, I added a minor version number to Contenticious.pm 