### PR TITLE
Keep up with changes to Mojo::Home

### DIFF
--- a/docs/customize.html
+++ b/docs/customize.html
@@ -44,8 +44,8 @@ your needs can be a smooth process. Just start with the simple parts.</strong></
 <p>Please look at the configuration file <code>config</code> first. It looks like this:</p>
 
 <pre><code>{
-    pages_dir   =&gt; app-&gt;home-&gt;rel_dir('pages'),
-    dump_dir    =&gt; app-&gt;home-&gt;rel_dir('dump'),
+    pages_dir   =&gt; app-&gt;home-&gt;rel_file('pages'),
+    dump_dir    =&gt; app-&gt;home-&gt;rel_file('dump'),
     name        =&gt; 'Shagadelic',
     copyright   =&gt; 'Zaphod Beeblebrox',
     cached      =&gt; 0,

--- a/lib/Contenticious.pm
+++ b/lib/Contenticious.pm
@@ -26,7 +26,7 @@ sub startup {
     my $config = $self->plugin(Config => {file => $config_file});
 
     # prepare content
-    $self->pages_dir($config->{pages_dir} // $self->home->rel_dir('pages'));
+    $self->pages_dir($config->{pages_dir} // $self->home->rel_file('pages'));
 
     # dumping needs relative URLs
     $self->plugin('RelativeUrlFor');

--- a/lib/Contenticious/Commands.pm
+++ b/lib/Contenticious/Commands.pm
@@ -12,7 +12,7 @@ sub dump {
 
     # prepare directory
     my $dd = $app->config->{dump_dir};
-    $dd  //= $app->home->rel_dir('dump');
+    $dd  //= $app->home->rel_file('dump');
 
     mkdir $dd unless -d $dd;
 

--- a/lib/Contenticious/Generator.pm
+++ b/lib/Contenticious/Generator.pm
@@ -38,8 +38,8 @@ __DATA__
 
 @@ config
 {
-    pages_dir   => app->home->rel_dir('pages'),
-    dump_dir    => app->home->rel_dir('dump'),
+    pages_dir   => app->home->rel_file('pages'),
+    dump_dir    => app->home->rel_file('dump'),
     name        => 'This is Contenticious.',
     copyright   => 'Zaphod Beeblebrox',
     cached      => 0,
@@ -139,7 +139,7 @@ tools to provide a smooth Markdown publishing workflow for you.
 It's developed as open source with one of the most free [licenses][license]
 (MIT License) to make it really easy for you to get your stuff done.
 
-* [**Follow Contenticious' development on github][repo]**  
+* [**Follow Contenticious' development on github][repo]**
     There you'll find a bug tracker, a wiki and all sources.
 
 Help testing and improving Contenticious!

--- a/t/03_generate.t
+++ b/t/03_generate.t
@@ -34,8 +34,8 @@ $generator->init;
 # config file
 is(slurp('config'), <<'EOD', 'right config file content');
 {
-    pages_dir   => app->home->rel_dir('pages'),
-    dump_dir    => app->home->rel_dir('dump'),
+    pages_dir   => app->home->rel_file('pages'),
+    dump_dir    => app->home->rel_file('dump'),
     name        => 'This is Contenticious.',
     copyright   => 'Zaphod Beeblebrox',
     cached      => 0,
@@ -143,7 +143,7 @@ tools to provide a smooth Markdown publishing workflow for you.
 It's developed as open source with one of the most free [licenses][license]
 (MIT License) to make it really easy for you to get your stuff done.
 
-* [**Follow Contenticious' development on github][repo]**  
+* [**Follow Contenticious' development on github][repo]**
     There you'll find a bug tracker, a wiki and all sources.
 
 Help testing and improving Contenticious!

--- a/t/test_config
+++ b/t/test_config
@@ -1,6 +1,6 @@
 {
-    pages_dir   => app->home->rel_dir('test_pages'),
-    dump_dir    => app->home->rel_dir('test_dump'),
+    pages_dir   => app->home->rel_file('test_pages'),
+    dump_dir    => app->home->rel_file('test_dump'),
     name        => 'Shagadelic',
     copyright   => 'Zaphod Beeblebrox',
     cached      => 0,


### PR DESCRIPTION
## Problem
Tests are creating warnings about deprecated `rel_dir` method.

```
Mojo::Home::rel_dir is DEPRECATED in favor of Mojo::Home::rel_file at (eval 75) line 2.
Mojo::Home::parts is DEPRECATED at (eval 75) line 2.
Mojo::Home::rel_dir is DEPRECATED in favor of Mojo::Home::rel_file at (eval 75) line 2.
Mojo::Home::parts is DEPRECATED at (eval 75) line 2.
```

`Mojo::Home::rel_dir` was deprecated in [`7.14`](https://github.com/kraih/mojo/blob/master/Changes#L61)

## Solution
Quick `s/rel_dir/rel_file/g`
